### PR TITLE
fix HYW wargoal to mod version

### DIFF
--- a/common/cb_types/00_cb_types.txt
+++ b/common/cb_types/00_cb_types.txt
@@ -41,31 +41,31 @@ cb_restore_personal_union = {
 }
 
 #Hundred Years War
-cb_hundred_years_war = {
-	valid_for_subject = no
+#cb_hundred_years_war = {
+	#valid_for_subject = no
 
-	is_triggered_only = yes
-	months = 240
+	#is_triggered_only = yes
+	#months = 240
 
-	prerequisites = {
-		OR = {
-			government = monarchy
-			has_reform = dutch_republic
-		}
-		is_revolutionary = no
-		FROM = {
-			OR = {
-				government = monarchy
-				has_reform = ambrosian_republic
-				# has_reform = military_dictatorship_reform
-				has_country_flag = neapolitan_republic
-			}
-			is_subject = no
-		}
-	}
+	#prerequisites = {
+		#OR = {
+			#government = monarchy
+			#has_reform = dutch_republic
+		#}
+		#is_revolutionary = no
+		#FROM = {
+			#OR = {
+				#government = monarchy
+				#has_reform = ambrosian_republic
+				## has_reform = military_dictatorship_reform
+				#has_country_flag = neapolitan_republic
+			#}
+			#is_subject = no
+		#}
+	#}
 
-	war_goal = take_capital_hundred_years_war
-}
+	#war_goal = take_capital_hundred_years_war
+#}
 
 # Defected province
 cb_defection = {


### PR DESCRIPTION
Reverts HYW wargoal to mod version, as the Paradox version does not allow for conquest of individual provinces from the English side.